### PR TITLE
Use staging environment by default in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 COPY ./target/x86_64-unknown-linux-musl/release/webapp .
 COPY ./Rocket.toml .
-ENV ROCKET_ENV development
+ENV ROCKET_ENV staging
 EXPOSE 8000
 ENTRYPOINT ["/webapp"]


### PR DESCRIPTION
Otherwise `/webapp` will bind to `localhost` *inside* the docker container. not helpful for exposing the service to the host.